### PR TITLE
Update recent activity wording

### DIFF
--- a/app/groups/[id]/page.tsx
+++ b/app/groups/[id]/page.tsx
@@ -228,19 +228,18 @@ export default function GroupDetailPage({ params }: { params: { id: string } }) 
   const calculateUserShare = useCallback((expense: Expense) => {
     if (!userPersona) return { amount: 0, type: 'none' }
     
-    const userSplit = expense.expense_splits.find(split => split.user_email === userPersona.email)
-    if (!userSplit) return { amount: 0, type: 'none' }
-    
-    const userAmount = userSplit.amount
     const isPaidByUser = expense.paid_by_email === userPersona.email
     
     if (isPaidByUser) {
-      // User paid the expense, show what they paid
-      return { amount: userAmount, type: 'paid' }
-    } else {
-      // User owes money, show what they owe
-      return { amount: userAmount, type: 'owe' }
+      // Show the total amount paid for the expense when the user is the payer
+      return { amount: expense.amount, type: 'paid' }
     }
+    
+    const userSplit = expense.expense_splits.find(split => split.user_email === userPersona.email)
+    if (!userSplit) return { amount: 0, type: 'none' }
+    
+    // Otherwise, show what the user owes for their share
+    return { amount: userSplit.amount, type: 'owe' }
   }, [userPersona])
 
   // Calculate balances and settlements


### PR DESCRIPTION
Show the full expense amount for the payer in the activity list.

Previously, when a user paid an expense, the UI displayed their individual share rather than the total amount they paid, leading to confusion (e.g., "You paid $20" instead of "You paid $30"). This change ensures the payer sees the full amount of the expense they covered.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa4d39fb-97a8-48a3-9d66-134c7a6c79dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aa4d39fb-97a8-48a3-9d66-134c7a6c79dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

